### PR TITLE
Bump dependencies

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -3,19 +3,6 @@
         "hash": {
             "sha256": "a28e60d6ec10434b5d5c40b6c3d799a45286fc0c6af7e2f5000aa77058933889"
         },
-        "host-environment-markers": {
-            "implementation_name": "cpython",
-            "implementation_version": "0",
-            "os_name": "posix",
-            "platform_machine": "x86_64",
-            "platform_python_implementation": "CPython",
-            "platform_release": "4.9.49-moby",
-            "platform_system": "Linux",
-            "platform_version": "#1 SMP Wed Sep 27 23:17:17 UTC 2017",
-            "python_full_version": "2.7.12",
-            "python_version": "2.7",
-            "sys_platform": "linux2"
-        },
         "pipfile-spec": 6,
         "requires": {},
         "sources": [
@@ -28,19 +15,45 @@
     },
     "default": {},
     "develop": {
-        "py": {
+        "attrs": {
             "hashes": [
-                "sha256:2ccb79b01769d99115aa600d7eed99f524bf752bba8f041dc1c184853514655a",
-                "sha256:0f2d585d22050e90c7d293b6451c83db097df77871974d90efd5a30dc12fcde3"
+                "sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836",
+                "sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99"
             ],
-            "version": "==1.4.34"
+            "markers": "python_version >= '3.6'",
+            "version": "==22.2.0"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
+                "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2",
+                "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==23.0"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
+                "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.0.0"
         },
         "pytest": {
             "hashes": [
-                "sha256:81a25f36a97da3313e1125fce9e7bbbba565bc7fec3c5beb14c262ddab238ac1",
-                "sha256:27fa6617efc2869d3e969a3e75ec060375bfb28831ade8b5cdd68da3a741dc3c"
+                "sha256:892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71",
+                "sha256:c4014eb40e10f11f355ad4e3c2fb2c6c6d1919c73f3b5a433de4708202cade59"
             ],
-            "version": "==3.2.3"
+            "index": "pypi",
+            "version": "==7.2.0"
         }
     }
 }


### PR DESCRIPTION
Was just trying this repo out and getting this error:

```
$ docker-compose run app py.test
Traceback (most recent call last):
  File "/root/.local/share/virtualenvs/app-4PlAip0Q/lib/python3.11/site-packages/py/_apipkg.py", line 118, in __makeattr
    modpath, attrname = self.__map__[name]
                        ~~~~~~~~~~~~^^^^^^
KeyError: '__spec__'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/root/.local/share/virtualenvs/app-4PlAip0Q/bin/py.test", line 5, in <module>
    from pytest import main
  File "/root/.local/share/virtualenvs/app-4PlAip0Q/lib/python3.11/site-packages/pytest.py", line 9, in <module>
    from _pytest.config import (
  File "/root/.local/share/virtualenvs/app-4PlAip0Q/lib/python3.11/site-packages/_pytest/config.py", line 13, in <module>
    import _pytest._code
  File "/root/.local/share/virtualenvs/app-4PlAip0Q/lib/python3.11/site-packages/_pytest/_code/__init__.py", line 3, in <module>
    from .code import Code  # noqa
    ^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/share/virtualenvs/app-4PlAip0Q/lib/python3.11/site-packages/_pytest/_code/code.py", line 11, in <module>
    reprlib = py.builtin._tryimport('repr', 'reprlib')
              ^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/share/virtualenvs/app-4PlAip0Q/lib/python3.11/site-packages/py/_apipkg.py", line 125, in __makeattr
    result = importobj(modpath, attrname)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/share/virtualenvs/app-4PlAip0Q/lib/python3.11/site-packages/py/_apipkg.py", line 48, in importobj
    module = __import__(modpath, None, None, ['__doc__'])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1138, in _find_and_load_unlocked
  File "/root/.local/share/virtualenvs/app-4PlAip0Q/lib/python3.11/site-packages/py/_apipkg.py", line 123, in __makeattr
    raise AttributeError(name)
AttributeError: __spec__
```

It seems to be [this issue](https://github.com/pytest-dev/py/issues/273), I ran `pipenv update` and it now passes:

```
$ docker-compose run app py.test
=========================================================== test session starts ===========================================================
platform linux -- Python 3.11.1, pytest-7.2.0, pluggy-1.0.0
rootdir: /app
collected 1 item

test_example.py .                                                                                                                   [100%]

============================================================ 1 passed in 0.00s ============================================================
```